### PR TITLE
Fix for iOS and tvOS devices passing checkFiles=1.

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -182,7 +182,7 @@ def VideoBrowse(url, title):
 
 ####################################################################################################
 @route(PREFIX + '/createvideoclipobject', duration=int, include_container=bool)
-def CreateVideoClipObject(smil_url, title, summary, duration, thumb, include_container=False):
+def CreateVideoClipObject(smil_url, title, summary, duration, thumb, include_container=False, checkFiles=False):
 
     videoclip_obj = VideoClipObject(
         key = Callback(CreateVideoClipObject, smil_url=smil_url, title=title, summary=summary, duration=duration, thumb=thumb, include_container=True),


### PR DESCRIPTION
Could not find any documentation on what checkFiles is for - but iOS client appends this to the query string